### PR TITLE
Backport AbuseFilterShouldFilterAction hook from MW 1.34

### DIFF
--- a/includes/AFComputedVariable.php
+++ b/includes/AFComputedVariable.php
@@ -333,6 +333,7 @@ class AFComputedVariable {
 
 				$revision = $title->getFirstRevision();
 				if ( $revision ) {
+					// TODO T233241
 					$result = $revision->getUserText();
 				} else {
 					$result = '';
@@ -452,7 +453,12 @@ class AFComputedVariable {
 				$revAuthors = $dbr->selectFieldValues(
 					$revQuery['tables'],
 					$revQuery['fields']['rev_user_text'],
-					[ 'rev_page' => $title->getArticleID() ],
+					[
+						'rev_page' => $title->getArticleID(),
+						// TODO Should deleted names be counted in the 10 authors? If yes, this check should
+						// be moved inside the foreach
+						'rev_deleted' => 0
+					],
 					$fname,
 					// Some pages have < 10 authors but many revisions (e.g. bot pages)
 					[ 'ORDER BY' => 'rev_timestamp DESC, rev_id DESC',

--- a/includes/AbuseFilter.php
+++ b/includes/AbuseFilter.php
@@ -1436,7 +1436,7 @@ class AbuseFilter {
 		// Only store the var dump if we're actually going to add log rows.
 		$var_dump = self::storeVarDump( $vars );
 		// To distinguish from stuff stored directly
-		$var_dump = "stored-text:$var_dump";
+		$var_dump = "tt:$var_dump";
 
 		$stash = ObjectCache::getMainStashInstance();
 
@@ -1503,7 +1503,7 @@ class AbuseFilter {
 		if ( count( $logged_global_filters ) ) {
 			$vars->computeDBVars();
 			$global_var_dump = self::storeVarDump( $vars, true );
-			$global_var_dump = "stored-text:$global_var_dump";
+			$global_var_dump = "tt:$global_var_dump";
 			foreach ( $central_log_rows as $index => $data ) {
 				$central_log_rows[$index]['afl_var_dump'] = $global_var_dump;
 			}
@@ -1540,7 +1540,7 @@ class AbuseFilter {
 	 * @param AbuseFilterVariableHolder $vars
 	 * @param bool $global
 	 *
-	 * @return int|null
+	 * @return int The insert ID.
 	 */
 	public static function storeVarDump( AbuseFilterVariableHolder $vars, $global = false ) {
 		global $wgCompressRevisions;
@@ -1550,8 +1550,8 @@ class AbuseFilter {
 		$vars = $vars->dumpAllVars( [ 'old_wikitext', 'new_wikitext' ] );
 
 		// Vars is an array with native PHP data types (non-objects) now
-		$text = serialize( $vars );
-		$flags = [ 'nativeDataArray' ];
+		$text = FormatJson::encode( $vars );
+		$flags = [ 'utf-8' ];
 
 		if ( $wgCompressRevisions && function_exists( 'gzdeflate' ) ) {
 			$text = gzdeflate( $text );
@@ -1566,12 +1566,8 @@ class AbuseFilter {
 			} else {
 				$text = ExternalStore::insertToDefault( $text );
 			}
-			$flags[] = 'external';
 
-			if ( !$text ) {
-				// Not mission-critical, just return nothing
-				return null;
-			}
+			$flags[] = 'external';
 		}
 
 		// Store to text table
@@ -1596,11 +1592,14 @@ class AbuseFilter {
 	 *
 	 * @param string $stored_dump
 	 *
-	 * @return array|object|AbuseFilterVariableHolder|bool
+	 * @return AbuseFilterVariableHolder|array
 	 */
 	public static function loadVarDump( $stored_dump ) {
-		// Backward compatibility
-		if ( substr( $stored_dump, 0, strlen( 'stored-text:' ) ) !== 'stored-text:' ) {
+		// Backward compatibility for (old) blobs stored in the abuse_filter_log table
+		if ( !is_numeric( $stored_dump ) &&
+			substr( $stored_dump, 0, strlen( 'stored-text:' ) ) !== 'stored-text:' &&
+			substr( $stored_dump, 0, strlen( 'tt:' ) ) !== 'tt:'
+		) {
 			$data = unserialize( $stored_dump );
 			if ( is_array( $data ) ) {
 				$vh = new AbuseFilterVariableHolder;
@@ -1614,7 +1613,15 @@ class AbuseFilter {
 			}
 		}
 
-		$text_id = substr( $stored_dump, strlen( 'stored-text:' ) );
+		if ( is_numeric( $stored_dump ) ) {
+			$text_id = (int)$stored_dump;
+		} elseif ( strpos( $stored_dump, 'stored-text:' ) !== false ) {
+			$text_id = (int)str_replace( 'stored-text:', '', $stored_dump );
+		} elseif ( strpos( $stored_dump, 'tt:' ) !== false ) {
+			$text_id = (int)str_replace( 'tt:', '', $stored_dump );
+		} else {
+			throw new LogicException( "Cannot understand format: $stored_dump" );
+		}
 
 		$dbr = wfGetDB( DB_REPLICA );
 
@@ -1626,10 +1633,12 @@ class AbuseFilter {
 		);
 
 		if ( !$text_row ) {
+			$logger = LoggerFactory::getInstance( 'AbuseFilter' );
+			$logger->warning( __METHOD__ . ": no text row found for input $stored_dump." );
 			return new AbuseFilterVariableHolder;
 		}
 
-		$flags = explode( ',', $text_row->old_flags );
+		$flags = $text_row->old_flags === '' ? [] : explode( ',', $text_row->old_flags );
 		$text = $text_row->old_text;
 
 		if ( in_array( 'external', $flags ) ) {
@@ -1640,9 +1649,17 @@ class AbuseFilter {
 			$text = gzinflate( $text );
 		}
 
-		$obj = unserialize( $text );
+		$obj = FormatJson::decode( $text, true );
+		if ( $obj === null ) {
+			// Temporary code until all rows will be JSON-encoded
+			$obj = unserialize( $text );
+		}
 
-		if ( in_array( 'nativeDataArray', $flags ) ) {
+		if ( in_array( 'nativeDataArray', $flags ) ||
+			// Temporary condition: we don't add the flag anymore, but the updateVarDump
+			// script could be still running and we cannot assume that this branch is the default.
+			( is_array( $obj ) && array_key_exists( 'action', $obj ) )
+		) {
 			$vars = $obj;
 			$obj = new AbuseFilterVariableHolder();
 			foreach ( $vars as $key => $value ) {

--- a/includes/AbuseFilter.php
+++ b/includes/AbuseFilter.php
@@ -1139,6 +1139,26 @@ class AbuseFilter {
 		AbuseFilterVariableHolder $vars, $title, $group, User $user, $mode = 'execute'
 	) {
 		global $wgAbuseFilterLogIP;
+		/**
+		 * Fandom change - begin
+		 *
+		 * Backports from AbuseFilterShouldFilterAction from 1.34 until we are able to
+		 * upgrade to MW 1.34
+		 */
+		$skipReasons = [];
+		$shouldFilter = Hooks::run(
+			'AbuseFilterShouldFilterAction',
+			[ $vars, $title, $user, &$skipReasons ]
+		);
+		if ( !$shouldFilter ) {
+			$logger = LoggerFactory::getInstance( 'AbuseFilter' );
+			$action = $vars->getVar( 'action' )->toString();
+			$logger->info( "Skipping action {$action}. Reasons provided: " . implode( ', ', $skipReasons ) );
+			return Status::newGood();
+		}
+		/**
+		 * Fandom change - end
+		 */
 
 		$logger = LoggerFactory::getInstance( 'StashEdit' );
 		$statsd = MediaWikiServices::getInstance()->getStatsdDataFactory();

--- a/includes/AbuseFilterChangesList.php
+++ b/includes/AbuseFilterChangesList.php
@@ -26,6 +26,7 @@ class AbuseFilterChangesList extends OldChangesList {
 		if ( (int)$rc->getAttribute( 'rc_deleted' ) !== 0 ) {
 			$s .= ' ' . $this->msg( 'abusefilter-log-hidden-implicit' )->parse();
 			if ( !$this->userCan( $rc, Revision::SUPPRESSED_ALL ) ) {
+				// Remember to keep this in sync with the CheckMatch API
 				return;
 			}
 		}

--- a/includes/AbuseFilterHooks.php
+++ b/includes/AbuseFilterHooks.php
@@ -367,10 +367,15 @@ class AbuseFilterHooks {
 	 * @param string $reason
 	 * @param string &$error
 	 * @param Status $status
+	 * @param bool $suppress
 	 * @return bool
 	 */
 	public static function onArticleDelete( WikiPage $article, User $user, $reason, &$error,
-		Status $status ) {
+		Status $status, bool $suppress ) {
+		if ( $suppress ) {
+			// Don't filter suppressions, T71617
+			return true;
+		}
 		$vars = new AbuseFilterVariableHolder;
 
 		$vars->addHolders(

--- a/includes/AbuseFilterPreAuthenticationProvider.php
+++ b/includes/AbuseFilterPreAuthenticationProvider.php
@@ -23,14 +23,15 @@ class AbuseFilterPreAuthenticationProvider extends AbstractPreAuthenticationProv
 	public function testUserForCreation( $user, $autocreate, array $options = [] ) {
 		// if this is not an autocreation, testForAccountCreation already handled it
 		if ( $autocreate ) {
-			return $this->testUser( $user, $user, true );
+			// FIXME Using the constructor directly here a bit hacky but needed for T272244
+			return $this->testUser( $user, new User, true );
 		}
 		return StatusValue::newGood();
 	}
 
 	/**
 	 * @param User $user The user being created or autocreated
-	 * @param User $creator The user who caused $user to be created (or $user itself on autocreation)
+	 * @param User $creator The user who caused $user to be created (can be anonymous)
 	 * @param bool $autocreate Is this an autocreation?
 	 * @return StatusValue
 	 */

--- a/includes/Views/AbuseFilterView.php
+++ b/includes/Views/AbuseFilterView.php
@@ -329,6 +329,14 @@ abstract class AbuseFilterView extends ContextSource {
 	}
 
 	/**
+	 * @todo Check what the user can actually see and use a proper bitmask. Core should provide such a method though.
+	 * @return array
+	 */
+	public function buildVisibilityConditions() : array {
+		return [ 'rc_deleted' => 0 ];
+	}
+
+	/**
 	 * @param string|int $id
 	 * @param string|null $text
 	 * @return string HTML

--- a/includes/Views/AbuseFilterView.php
+++ b/includes/Views/AbuseFilterView.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Revision\RevisionRecord;
 use Wikimedia\Rdbms\IDatabase;
 
 abstract class AbuseFilterView extends ContextSource {
@@ -329,11 +330,22 @@ abstract class AbuseFilterView extends ContextSource {
 	}
 
 	/**
-	 * @todo Check what the user can actually see and use a proper bitmask. Core should provide such a method though.
+	 * @todo Core should provide a method for this (T233222)
+	 * @param IDatabase $db
+	 * @param User $user
 	 * @return array
 	 */
-	public function buildVisibilityConditions() : array {
-		return [ 'rc_deleted' => 0 ];
+	public function buildVisibilityConditions( IDatabase $db, User $user ) : array {
+		if ( !$user->isAllowed( 'deletedhistory' ) ) {
+			$bitmask = RevisionRecord::DELETED_USER;
+		} elseif ( !$user->isAllowedAny( 'suppressrevision', 'viewsuppressed' ) ) {
+			$bitmask = RevisionRecord::DELETED_USER | RevisionRecord::DELETED_RESTRICTED;
+		} else {
+			$bitmask = 0;
+		}
+		return $bitmask
+			? [ $db->bitAnd( 'rc_deleted', $bitmask ) . " != $bitmask" ]
+			: [];
 	}
 
 	/**

--- a/includes/Views/AbuseFilterViewTestBatch.php
+++ b/includes/Views/AbuseFilterViewTestBatch.php
@@ -168,7 +168,7 @@ class AbuseFilterViewTestBatch extends AbuseFilterView {
 
 		$action = $this->mTestAction !== '0' ? $this->mTestAction : false;
 		$conds[] = $this->buildTestConditions( $dbr, $action );
-		$conds = array_merge( $conds, $this->buildVisibilityConditions() );
+		$conds = array_merge( $conds, $this->buildVisibilityConditions( $dbr, $this->getUser() ) );
 
 		// Get our ChangesList
 		$changesList = new AbuseFilterChangesList( $this->getSkin(), $this->mFilter );

--- a/includes/Views/AbuseFilterViewTestBatch.php
+++ b/includes/Views/AbuseFilterViewTestBatch.php
@@ -168,6 +168,7 @@ class AbuseFilterViewTestBatch extends AbuseFilterView {
 
 		$action = $this->mTestAction !== '0' ? $this->mTestAction : false;
 		$conds[] = $this->buildTestConditions( $dbr, $action );
+		$conds = array_merge( $conds, $this->buildVisibilityConditions() );
 
 		// Get our ChangesList
 		$changesList = new AbuseFilterChangesList( $this->getSkin(), $this->mFilter );

--- a/includes/Views/AbuseFilterViewTestBatch.php
+++ b/includes/Views/AbuseFilterViewTestBatch.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Storage\RevisionRecord;
+
 class AbuseFilterViewTestBatch extends AbuseFilterView {
 	// Hard-coded for now.
 	protected static $mChangeLimit = 100;
@@ -183,7 +185,34 @@ class AbuseFilterViewTestBatch extends AbuseFilterView {
 
 		$counter = 1;
 
+		$contextUser = $this->getUser();
 		foreach ( $res as $row ) {
+			$rc = RecentChange::newFromRow( $row );
+			if ( !$this->mShowNegative ) {
+				$type = (int)$rc->getAttribute( 'rc_type' );
+				$deletedValue = $rc->getAttribute( 'rc_deleted' );
+				if (
+					(
+						$type === RC_LOG &&
+						!LogEventsList::userCanBitfield(
+							$deletedValue,
+							LogPage::SUPPRESSED_ACTION | LogPage::SUPPRESSED_USER,
+							$contextUser
+						)
+					) || (
+						$type !== RC_LOG &&
+						!RevisionRecord::userCanBitfield(
+							$deletedValue, RevisionRecord::SUPPRESSED_ALL, $contextUser
+						)
+					)
+				) {
+					// If the RC is deleted, the user can't see it, and we're only showing matches,
+					// always skip this row. If mShowNegative is true, we can still show the row
+					// because we won't tell whether it matches the given filter.
+					continue;
+				}
+			}
+
 			$vars = AbuseFilter::getVarsFromRCRow( $row );
 
 			if ( !$vars ) {

--- a/includes/api/ApiAbuseFilterCheckMatch.php
+++ b/includes/api/ApiAbuseFilterCheckMatch.php
@@ -1,10 +1,13 @@
 <?php
 
+use MediaWiki\Storage\RevisionRecord;
+
 class ApiAbuseFilterCheckMatch extends ApiBase {
 	/**
 	 * @see ApiBase::execute
 	 */
 	public function execute() {
+		$user = $this->getUser();
 		$params = $this->extractRequestParams();
 		$this->requireOnlyOneParameter( $params, 'vars', 'rcid', 'logid' );
 
@@ -36,15 +39,42 @@ class ApiAbuseFilterCheckMatch extends ApiBase {
 				$this->dieWithError( [ 'apierror-nosuchrcid', $params['rcid'] ] );
 			}
 
+			$rc = RecentChange::newFromRow( $row );
+			$type = (int)$rc->getAttribute( 'rc_type' );
+			$deletedValue = $rc->getAttribute( 'rc_deleted' );
+			if (
+				(
+					$type === RC_LOG &&
+					!LogEventsList::userCanBitfield(
+						$deletedValue,
+						LogPage::SUPPRESSED_ACTION | LogPage::SUPPRESSED_USER,
+						$user
+					)
+				) || (
+					$type !== RC_LOG &&
+					!RevisionRecord::userCanBitfield( $deletedValue, RevisionRecord::SUPPRESSED_ALL, $user )
+				)
+			) {
+				// T223654 - Same check as in AbuseFilterChangesList
+				$this->dieWithError( 'apierror-permissiondenied-generic', 'deletedrc' );
+			}
+
 			$vars = AbuseFilter::getVarsFromRCRow( $row );
 		} elseif ( $params['logid'] ) {
 			$dbr = wfGetDB( DB_REPLICA );
 			$row = $dbr->selectRow(
 				'abuse_filter_log',
-				'afl_var_dump',
+				'*',
 				[ 'afl_id' => $params['logid'] ],
 				__METHOD__
 			);
+
+			$permManager = MediaWikiServices::getInstance()->getPermissionManager();
+			if ( !$user->isAllowed( 'abusefilter-hidden-log' ) && SpecialAbuseLog::isHidden( $row ) ) {
+				// T223654 - Same check as in SpecialAbuseLog. Both the visibility of the AbuseLog entry
+				// and the corresponding revision are checked.
+				$this->dieWithError( 'apierror-permissiondenied-generic', 'deletedabuselog' );
+			}
 
 			if ( !$row ) {
 				$this->dieWithError( [ 'apierror-abusefilter-nosuchlogid', $params['logid'] ], 'nosuchlogid' );

--- a/includes/pagers/AbuseFilterExaminePager.php
+++ b/includes/pagers/AbuseFilterExaminePager.php
@@ -36,12 +36,13 @@ class AbuseFilterExaminePager extends ReverseChronologicalPager {
 		}
 
 		$conds[] = $this->mPage->buildTestConditions( $dbr );
+		$conds = array_merge( $conds, $this->mPage->buildVisibilityConditions() );
 
 		$rcQuery = RecentChange::getQueryInfo();
 		$info = [
 			'tables' => $rcQuery['tables'],
 			'fields' => $rcQuery['fields'],
-			'conds' => array_filter( $conds ),
+			'conds' => $conds,
 			'options' => [ 'ORDER BY' => 'rc_timestamp DESC' ],
 			'join_conds' => $rcQuery['joins'],
 		];

--- a/includes/pagers/AbuseFilterExaminePager.php
+++ b/includes/pagers/AbuseFilterExaminePager.php
@@ -36,7 +36,7 @@ class AbuseFilterExaminePager extends ReverseChronologicalPager {
 		}
 
 		$conds[] = $this->mPage->buildTestConditions( $dbr );
-		$conds = array_merge( $conds, $this->mPage->buildVisibilityConditions() );
+		$conds = array_merge( $conds, $this->mPage->buildVisibilityConditions( $dbr, $this->getUser() ) );
 
 		$rcQuery = RecentChange::getQueryInfo();
 		$info = [

--- a/includes/parser/AFPData.php
+++ b/includes/parser/AFPData.php
@@ -346,7 +346,7 @@ class AFPData {
 		$a = $a->toNumber();
 		$b = $b->toNumber();
 
-		if ( $op !== '*' && $b === 0 ) {
+		if ( $op !== '*' && (float)$b === 0.0 ) {
 			throw new AFPUserVisibleException( 'dividebyzero', $pos, [ $a ] );
 		}
 

--- a/tests/phpunit/AFPDataTest.php
+++ b/tests/phpunit/AFPDataTest.php
@@ -117,6 +117,7 @@ class AFPDataTest extends MediaWikiTestCase {
 	public function divideByZero() {
 		return [
 			[ '1/0', 'mulRel' ],
+			[ '1/0.0', 'mulRel' ],
 		];
 	}
 }


### PR DESCRIPTION
This will allow us to implement AbuseFilterBypass now and have it not require changes
when we upgrade to newer versions.