### PR TITLE
IW-4836 | Start using new format for var dumps

### DIFF
--- a/includes/AbuseFilter.php
+++ b/includes/AbuseFilter.php
@@ -1436,7 +1436,7 @@ class AbuseFilter {
 		// Only store the var dump if we're actually going to add log rows.
 		$var_dump = self::storeVarDump( $vars );
 		// To distinguish from stuff stored directly
-		$var_dump = "stored-text:$var_dump";
+		$var_dump = "tt:$var_dump";
 
 		$stash = ObjectCache::getMainStashInstance();
 
@@ -1503,7 +1503,7 @@ class AbuseFilter {
 		if ( count( $logged_global_filters ) ) {
 			$vars->computeDBVars();
 			$global_var_dump = self::storeVarDump( $vars, true );
-			$global_var_dump = "stored-text:$global_var_dump";
+			$global_var_dump = "tt:$global_var_dump";
 			foreach ( $central_log_rows as $index => $data ) {
 				$central_log_rows[$index]['afl_var_dump'] = $global_var_dump;
 			}
@@ -1540,7 +1540,7 @@ class AbuseFilter {
 	 * @param AbuseFilterVariableHolder $vars
 	 * @param bool $global
 	 *
-	 * @return int|null
+	 * @return int The insert ID.
 	 */
 	public static function storeVarDump( AbuseFilterVariableHolder $vars, $global = false ) {
 		global $wgCompressRevisions;
@@ -1550,8 +1550,8 @@ class AbuseFilter {
 		$vars = $vars->dumpAllVars( [ 'old_wikitext', 'new_wikitext' ] );
 
 		// Vars is an array with native PHP data types (non-objects) now
-		$text = serialize( $vars );
-		$flags = [ 'nativeDataArray' ];
+		$text = FormatJson::encode( $vars );
+		$flags = [ 'utf-8' ];
 
 		if ( $wgCompressRevisions && function_exists( 'gzdeflate' ) ) {
 			$text = gzdeflate( $text );
@@ -1566,12 +1566,8 @@ class AbuseFilter {
 			} else {
 				$text = ExternalStore::insertToDefault( $text );
 			}
-			$flags[] = 'external';
 
-			if ( !$text ) {
-				// Not mission-critical, just return nothing
-				return null;
-			}
+			$flags[] = 'external';
 		}
 
 		// Store to text table
@@ -1596,11 +1592,14 @@ class AbuseFilter {
 	 *
 	 * @param string $stored_dump
 	 *
-	 * @return array|object|AbuseFilterVariableHolder|bool
+	 * @return AbuseFilterVariableHolder|array
 	 */
 	public static function loadVarDump( $stored_dump ) {
-		// Backward compatibility
-		if ( substr( $stored_dump, 0, strlen( 'stored-text:' ) ) !== 'stored-text:' ) {
+		// Backward compatibility for (old) blobs stored in the abuse_filter_log table
+		if ( !is_numeric( $stored_dump ) &&
+			substr( $stored_dump, 0, strlen( 'stored-text:' ) ) !== 'stored-text:' &&
+			substr( $stored_dump, 0, strlen( 'tt:' ) ) !== 'tt:'
+		) {
 			$data = unserialize( $stored_dump );
 			if ( is_array( $data ) ) {
 				$vh = new AbuseFilterVariableHolder;
@@ -1614,7 +1613,15 @@ class AbuseFilter {
 			}
 		}
 
-		$text_id = substr( $stored_dump, strlen( 'stored-text:' ) );
+		if ( is_numeric( $stored_dump ) ) {
+			$text_id = (int)$stored_dump;
+		} elseif ( strpos( $stored_dump, 'stored-text:' ) !== false ) {
+			$text_id = (int)str_replace( 'stored-text:', '', $stored_dump );
+		} elseif ( strpos( $stored_dump, 'tt:' ) !== false ) {
+			$text_id = (int)str_replace( 'tt:', '', $stored_dump );
+		} else {
+			throw new LogicException( "Cannot understand format: $stored_dump" );
+		}
 
 		$dbr = wfGetDB( DB_REPLICA );
 
@@ -1626,10 +1633,12 @@ class AbuseFilter {
 		);
 
 		if ( !$text_row ) {
+			$logger = LoggerFactory::getInstance( 'AbuseFilter' );
+			$logger->warning( __METHOD__ . ": no text row found for input $stored_dump." );
 			return new AbuseFilterVariableHolder;
 		}
 
-		$flags = explode( ',', $text_row->old_flags );
+		$flags = $text_row->old_flags === '' ? [] : explode( ',', $text_row->old_flags );
 		$text = $text_row->old_text;
 
 		if ( in_array( 'external', $flags ) ) {
@@ -1640,9 +1649,17 @@ class AbuseFilter {
 			$text = gzinflate( $text );
 		}
 
-		$obj = unserialize( $text );
+		$obj = FormatJson::decode( $text, true );
+		if ( $obj === null ) {
+			// Temporary code until all rows will be JSON-encoded
+			$obj = unserialize( $text );
+		}
 
-		if ( in_array( 'nativeDataArray', $flags ) ) {
+		if ( in_array( 'nativeDataArray', $flags ) ||
+			// Temporary condition: we don't add the flag anymore, but the updateVarDump
+			// script could be still running and we cannot assume that this branch is the default.
+			( is_array( $obj ) && array_key_exists( 'action', $obj ) )
+		) {
 			$vars = $obj;
 			$obj = new AbuseFilterVariableHolder();
 			foreach ( $vars as $key => $value ) {


### PR DESCRIPTION
Backport https://gerrit.wikimedia.org/r/c/mediawiki/extensions/AbuseFilter/+/482500/ to start writing new AFL log entries in JSON format, while keeping B/C with old serialized entries. Once this is deployed, we can run the migration to convert legacy entries.