### PR TITLE
Restore check for dividebyzero

### DIFF
--- a/includes/parser/AFPData.php
+++ b/includes/parser/AFPData.php
@@ -346,7 +346,7 @@ class AFPData {
 		$a = $a->toNumber();
 		$b = $b->toNumber();
 
-		if ( $op !== '*' && $b === 0 ) {
+		if ( $op !== '*' && (float)$b === 0.0 ) {
 			throw new AFPUserVisibleException( 'dividebyzero', $pos, [ $a ] );
 		}
 

--- a/tests/phpunit/AFPDataTest.php
+++ b/tests/phpunit/AFPDataTest.php
@@ -117,6 +117,7 @@ class AFPDataTest extends MediaWikiTestCase {
 	public function divideByZero() {
 		return [
 			[ '1/0', 'mulRel' ],
+			[ '1/0.0', 'mulRel' ],
 		];
 	}
 }


### PR DESCRIPTION
Follow-up of I1721a3ba532d481e3ecf35f51099c1438b6b73b2. This is the only
wrong replacement: strict checking will let 5 / 0.0 pass, with
unexpected results. Adding a regression test for it, too.

Change-Id: I25dbe9fafa92fd9a11bd8bc6ab8e66f305b8d48e